### PR TITLE
Use hash:net with ipset, not hash:ip

### DIFF
--- a/roles/common/templates/setup_ip_whitelist.sh.j2
+++ b/roles/common/templates/setup_ip_whitelist.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ipset create whitelist -! hash:ip
+ipset create whitelist -! hash:net
 
 # User IPs
 {% for local_ip in local_ips %}


### PR DESCRIPTION
hash:ip is not suited for storing ip ranges and you will quickly hit the limit for the list. Switching to hash:net is better proofed against problems like this.

Note: This will not actually upgrade the existing list on re-run, you would need to create the new set manually, then fill it, then swap the two lists.