### PR TITLE
Vagrant test env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.idea
+.vagrant
+roles/*\.*
+inventory
 playbook.retry
 vars.yaml
-.idea
-inventory

--- a/README.md
+++ b/README.md
@@ -56,3 +56,19 @@ Add an IP to `local_ips` list in `vars.yaml.example` and run
 ```$ ansible-playbook -i inventory playbook.yml -t firewall```
 
 This will update the ipset rules. To learn more about the firewall read this [blog post](http://container-solutions.com/how-to-secure-dcos-packet-cluster-ip-whitelisting-ipset/)
+
+## Testing
+
+A Vagrant environment is available for local testing of setups.
+
+Requirements:
+
+- Vagrant + Virtualbox
+- 'vagrant-reload' plugin (https://github.com/aidanns/vagrant-reload)
+
+To provision the testing environment:
+
+- create a `vars.yaml` and set `net_interface`/`net_interface_label` vars to "eth1" and `cloud` to "vagrant" (for the specific "detect-ip" script)
+- execute `$ vagrant up`
+
+VM hosts (and respective static IP addresses) are defined in the `tests/vagrant-hosts.yml` YAML file

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Requirements:
 - Vagrant + Virtualbox
 - 'vagrant-reload' plugin (https://github.com/aidanns/vagrant-reload)
 
-To provision the testing environment:
+A sample vars file is available under `tests/vars.yaml.sample`, which should be copied 
+to the project root folder as `vars.yaml` and adapted as necessary (particularly `local_ips`).
 
-- create a `vars.yaml` and set `net_interface`/`net_interface_label` vars to "eth1" and `cloud` to "vagrant" (for the specific "detect-ip" script)
-- execute `$ vagrant up`
+VM hosts (and respective static IP addresses) are defined in the `tests/vagrant-hosts.yml` YAML file.
 
-VM hosts (and respective static IP addresses) are defined in the `tests/vagrant-hosts.yml` YAML file
+To provision the testing environment execute `$ vagrant up` in the project root.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 require 'yaml'
  
 # Read YAML file with box details
-servers = YAML.load_file('vagrant-hosts.yml')
+servers = YAML.load_file('tests/vagrant-hosts.yml')
 
 Vagrant.configure("2") do |config|
 
@@ -18,15 +18,24 @@ Vagrant.configure("2") do |config|
 
   (0..N).each do |machine_id|
     config.vm.define servers[machine_id]["name"] do |srv|
-      #srv.vm.network "private_network", ip: server["ip"]
+      srv.vm.network "private_network", ip: servers[machine_id]["ip"], virtualbox__intnet: true
+      #config.vm.network "public_network"
       srv.vm.provider :virtualbox do |vb|
         vb.name = servers[machine_id]["name"]
         vb.memory = servers[machine_id]["memory"]
       end
 
+      srv.vm.provision :shell do |shell|
+        shell.path = "tests/bootstrap-vagrant.sh"
+      end
+
+      # Reboot to apply selinux config
+      srv.vm.provision :reload
+
       # Only execute once the Ansible provisioner,
       # when all the machines are up and ready.
       if machine_id == N
+
         # Run Ansible from the Vagrant Host
         config.vm.provision "ansible" do |ansible|
           # Disable default limit to connect to all the machines
@@ -34,6 +43,9 @@ Vagrant.configure("2") do |config|
           ansible.playbook = "playbook.yml"
           ansible.become = true
           ansible.become_user = "root"
+          
+          # temp
+          ansible.skip_tags = "firewall"
           ansible.galaxy_role_file = "requirements.yml"
           ansible.groups = {
             "bootstrap"   => ["bootstrap"],
@@ -41,8 +53,9 @@ Vagrant.configure("2") do |config|
             "pubagents"   => ["public_agent"],
             "agents"      => ["private_agent"]
           }
-          ansible.verbose = "vvv"
+          #ansible.verbose = "vvv"
         end
+
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,49 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Require YAML module
+require 'yaml'
+ 
+# Read YAML file with box details
+servers = YAML.load_file('vagrant-hosts.yml')
+
+Vagrant.configure("2") do |config|
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "centos/7"
+
+  # Iterate through entries in YAML file
+  N = servers.length - 1
+
+  (0..N).each do |machine_id|
+    config.vm.define servers[machine_id]["name"] do |srv|
+      #srv.vm.network "private_network", ip: server["ip"]
+      srv.vm.provider :virtualbox do |vb|
+        vb.name = servers[machine_id]["name"]
+        vb.memory = servers[machine_id]["memory"]
+      end
+
+      # Only execute once the Ansible provisioner,
+      # when all the machines are up and ready.
+      if machine_id == N
+        # Run Ansible from the Vagrant Host
+        config.vm.provision "ansible" do |ansible|
+          # Disable default limit to connect to all the machines
+          ansible.limit = "all"
+          ansible.playbook = "playbook.yml"
+          ansible.become = true
+          ansible.become_user = "root"
+          ansible.galaxy_role_file = "requirements.yml"
+          ansible.groups = {
+            "bootstrap"   => ["bootstrap"],
+            "masters"     => ["master"],
+            "pubagents"   => ["public_agent"],
+            "agents"      => ["private_agent"]
+          }
+          ansible.verbose = "vvv"
+        end
+      end
+    end
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,8 +18,8 @@ Vagrant.configure("2") do |config|
 
   (0..N).each do |machine_id|
     config.vm.define servers[machine_id]["name"] do |srv|
-      srv.vm.network "private_network", ip: servers[machine_id]["ip"], virtualbox__intnet: true
-      #config.vm.network "public_network"
+      srv.vm.network "private_network", ip: servers[machine_id]["ip"]
+
       srv.vm.provider :virtualbox do |vb|
         vb.name = servers[machine_id]["name"]
         vb.memory = servers[machine_id]["memory"]
@@ -29,7 +29,8 @@ Vagrant.configure("2") do |config|
         shell.path = "tests/bootstrap-vagrant.sh"
       end
 
-      # Reboot to apply selinux config
+      # Reboot to apply selinux config.
+      # Requires https://github.com/aidanns/vagrant-reload
       srv.vm.provision :reload
 
       # Only execute once the Ansible provisioner,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure("2") do |config|
       if machine_id == N
 
         # Run Ansible from the Vagrant Host
-        config.vm.provision "ansible" do |ansible|
+        srv.vm.provision "ansible" do |ansible|
           # Disable default limit to connect to all the machines
           ansible.limit = "all"
           ansible.playbook = "playbook.yml"

--- a/roles/agent/tasks/main.yaml
+++ b/roles/agent/tasks/main.yaml
@@ -3,12 +3,13 @@
 - name: Ensure dcos_install.sh is downloaded from bootstrap server
   get_url:
     url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_bond0_0']['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
-    dest: /root/dcos_install.sh
+    dest: "{{ dcos_download_path }}/dcos_install.sh"
     mode: 755
   tags: install-agent
 
 - name: Install DC/OS agent
-  shell: /root/dcos_install.sh slave > dcos_install.log
+  shell: "{{ dcos_download_path }}/dcos_install.sh slave > {{ dcos_download_path }}/dcos_install.log"
   args:
     creates: /etc/systemd/system/dcos.target
+    chdir: "{{ dcos_download_path }}"
   tags: install-agent

--- a/roles/agent/tasks/main.yaml
+++ b/roles/agent/tasks/main.yaml
@@ -2,7 +2,7 @@
 
 - name: Ensure dcos_install.sh is downloaded from bootstrap server
   get_url:
-    url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_bond0_0']['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
+    url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_'+net_interface_label]['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
     dest: "{{ dcos_download_path }}/dcos_install.sh"
     mode: 755
   tags: install-agent

--- a/roles/bootstrap/files/ip-detect-vagrant.sh
+++ b/roles/bootstrap/files/ip-detect-vagrant.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -o nounset -o errexit
+export PATH=/usr/sbin:/usr/bin:$PATH
+echo $(ip address show eth1 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -1,28 +1,29 @@
 ---
 - name: Ensures genconf dir exists
-  file: path=genconf state=directory
+  file: path="{{ dcos_download_path }}/genconf" state=directory
   tags: genconf
 
 - name: Copy ip-detect script
-  copy: src=files/ip-detect-{{ cloud }}.sh dest=/root/genconf/ip-detect owner=root group=root mode=0755
+  copy: src=files/ip-detect-{{ cloud }}.sh dest="{{ dcos_download_path }}/genconf/ip-detect" owner=root group=root mode=0755
   tags: ipdetect
 
 - name: Copy config.yaml template
-  template: src=templates/config.yaml.j2 dest=/root/genconf/config.yaml owner=root group=root
+  template: src=templates/config.yaml.j2 dest="{{ dcos_download_path }}/genconf/config.yaml" owner=root group=root
   tags: config
 
 - name: Download dcos_generate_config.sh
   get_url:
     url: "{{ dcos_download_url }}"
-    dest: /root/dcos_generate_config.sh
+    dest: "{{ dcos_download_path }}/dcos_generate_config.sh"
     mode: 755
   tags: dcos_generate_config
   when: not ansible_check_mode
 
 - name: Execute dcos_generate_config.sh
-  shell: /root/dcos_generate_config.sh
+  shell: "{{ dcos_download_path }}/dcos_generate_config.sh"
   args:
    creates: /etc/systemd/system/dcos.target
+   chdir: "{{ dcos_download_path }}"
   tags: dcos_generate_config
   when: not ansible_check_mode
 
@@ -54,6 +55,6 @@
     command: nginx -g "daemon off;"
     image: nginx:1.13
     volumes:
-      - "/root/genconf/serve:/usr/share/nginx/html:ro" 
+      - "{{ dcos_download_path }}/genconf/serve:/usr/share/nginx/html:ro" 
     ports:
       - "{{ bootstrap_server_port }}:80"

--- a/roles/bootstrap/templates/config.yaml.j2
+++ b/roles/bootstrap/templates/config.yaml.j2
@@ -2,7 +2,7 @@
 bootstrap_url: http://{{ hostvars[inventory_hostname]['ansible_'+net_interface_label]['ipv4']['address'] }}:{{ bootstrap_server_port }}
 cluster_name: '{{ cluster_name }}'
 exhibitor_storage_backend: static
-ip_detect_filename: {{ dcos_download_path }}/genconf/ip-detect
+ip_detect_filename: /genconf/ip-detect
 master_discovery: static
 master_list:
 {% for master in groups['masters'] %}

--- a/roles/bootstrap/templates/config.yaml.j2
+++ b/roles/bootstrap/templates/config.yaml.j2
@@ -1,12 +1,12 @@
 ---
-bootstrap_url: http://{{ hostvars[inventory_hostname]['ansible_bond0_0']['ipv4']['address'] }}:{{ bootstrap_server_port }}
+bootstrap_url: http://{{ hostvars[inventory_hostname]['ansible_'+net_interface_label]['ipv4']['address'] }}:{{ bootstrap_server_port }}
 cluster_name: '{{ cluster_name }}'
 exhibitor_storage_backend: static
-ip_detect_filename: /genconf/ip-detect
+ip_detect_filename: {{ dcos_download_path }}/genconf/ip-detect
 master_discovery: static
 master_list:
 {% for master in groups['masters'] %}
-  - {{ hostvars[master]['ansible_bond0_0']['ipv4']['address'] }}
+  - {{ hostvars[master]['ansible_'+net_interface_label]['ipv4']['address'] }}
 {% endfor %}
 resolvers:
 {% for dns_server in dns_servers %}

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -28,8 +28,16 @@
     - jq
   tags: packages, common
 
+- name: Create DC/OS downloads directory
+  file:
+    path: "{{ dcos_download_path }}"
+    state: directory
+    mode: 0755
+    recurse: yes
+  tags: common
+
 - name: Ensure ipset script is uploaded
-  template: src=templates/setup_ip_whitelist.sh.j2 dest=/root/setup_ip_whitelist.sh mode=755 owner=root group=root mode=755
+  template: src=templates/setup_ip_whitelist.sh.j2 dest="{{ dcos_download_path }}/setup_ip_whitelist.sh" mode=755 owner=root group=root mode=755
   tags: firewall, common
 
 - name: Ensure syslog configuration for iptables log file
@@ -45,7 +53,7 @@
   tags: firewall, common
 
 - name: Ensure ipset script is executed
-  shell: ./setup_ip_whitelist.sh
+  shell: "{{ dcos_download_path }}/setup_ip_whitelist.sh"
   tags: firewall, common
 
 - name: Set up IPTables

--- a/roles/common/templates/setup_ip_whitelist.sh.j2
+++ b/roles/common/templates/setup_ip_whitelist.sh.j2
@@ -9,32 +9,32 @@ ipset add whitelist -! {{ local_ip }}
 
 # Public master IPs
 {% for host in groups['masters'] %}
-ipset add whitelist -! {{ hostvars[host]['ansible_bond0']['ipv4']['address'] }}
+ipset add whitelist -! {{ hostvars[host]['ansible_'+net_interface]['ipv4']['address'] }}
 {% endfor %}
 
 # Agent public IPs
 {% for host in groups['agents'] %}
-ipset add whitelist -! {{ hostvars[host]['ansible_bond0']['ipv4']['address'] }}
+ipset add whitelist -! {{ hostvars[host]['ansible_'+net_interface]['ipv4']['address'] }}
 {% endfor %}
 
 # Agent private IPs
 {% for host in groups['agents'] %}
-ipset add whitelist -! {{ hostvars[host]['ansible_bond0_0']['ipv4']['address'] }}
+ipset add whitelist -! {{ hostvars[host]['ansible_'+net_interface_label]['ipv4']['address'] }}
 {% endfor %}
 
 # Public agent public IPs
 {% for host in groups['pubagents'] %}
-ipset add whitelist -! {{ hostvars[host]['ansible_bond0']['ipv4']['address'] }}
+ipset add whitelist -! {{ hostvars[host]['ansible_'+net_interface]['ipv4']['address'] }}
 {% endfor %}
 
 # Public agent private IPs
 {% for host in groups['pubagents'] %}
-ipset add whitelist -! {{ hostvars[host]['ansible_bond0_0']['ipv4']['address'] }}
+ipset add whitelist -! {{ hostvars[host]['ansible_'+net_interface_label]['ipv4']['address'] }}
 {% endfor %}
 
 # Private master IPs
 {% for host in groups['masters'] %}
-ipset add whitelist -! {{ hostvars[host]['ansible_bond0_0']['ipv4']['address'] }}
+ipset add whitelist -! {{ hostvars[host]['ansible_'+net_interface_label]['ipv4']['address'] }}
 {% endfor %}
 
 # Loopback

--- a/roles/master/tasks/main.yaml
+++ b/roles/master/tasks/main.yaml
@@ -3,12 +3,13 @@
 - name: Ensure dcos_install.sh is downloaded from bootstrap server
   get_url:
     url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_bond0_0']['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
-    dest: /root/dcos_install.sh
+    dest: "{{ dcos_download_path }}/dcos_install.sh"
     mode: 755
   tags: install-master
 
 - name: Install DC/OS masters
-  shell: /root/dcos_install.sh master
+  shell: "{{ dcos_download_path }}/dcos_install.sh master"
   args:
     creates: /etc/systemd/system/dcos.target
+    chdir: "{{ dcos_download_path }}"
   tags: install-master

--- a/roles/master/tasks/main.yaml
+++ b/roles/master/tasks/main.yaml
@@ -2,7 +2,7 @@
 
 - name: Ensure dcos_install.sh is downloaded from bootstrap server
   get_url:
-    url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_bond0_0']['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
+    url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_'+net_interface_label]['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
     dest: "{{ dcos_download_path }}/dcos_install.sh"
     mode: 755
   tags: install-master

--- a/roles/pubagent/tasks/main.yaml
+++ b/roles/pubagent/tasks/main.yaml
@@ -3,12 +3,13 @@
 - name: Ensure dcos_install.sh is downloaded from bootstrap server
   get_url:
     url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_bond0_0']['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
-    dest: /root/dcos_install.sh
+    dest: "{{ dcos_download_path }}/dcos_install.sh"
     mode: 755
   tags: install-public-agent
 
 - name: Install DC/OS public agent
-  shell: /root/dcos_install.sh slave_public > dcos_install.log
+  shell: "{{ dcos_download_path }}/dcos_install.sh slave_public > {{ dcos_download_path }}/dcos_install.log"
   args:
     creates: /etc/systemd/system/dcos.target
+    chdir: "{{ dcos_download_path }}"
   tags: install-public-agent

--- a/roles/pubagent/tasks/main.yaml
+++ b/roles/pubagent/tasks/main.yaml
@@ -2,7 +2,7 @@
 
 - name: Ensure dcos_install.sh is downloaded from bootstrap server
   get_url:
-    url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_bond0_0']['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
+    url: "http://{{ hostvars[groups['bootstrap'][0]]['ansible_'+net_interface_label]['ipv4']['address'] }}:{{ bootstrap_server_port }}/dcos_install.sh"
     dest: "{{ dcos_download_path }}/dcos_install.sh"
     mode: 755
   tags: install-public-agent

--- a/tests/bootstrap-vagrant.sh
+++ b/tests/bootstrap-vagrant.sh
@@ -7,7 +7,7 @@ sed -i 's/SELINUX=\(disabled\|enforcing\)/SELINUX=permissive/g' /etc/selinux/con
 sestatus
 
 # workaround for 'bridge-nf-call-ip6tables is disabled' public_agent warning
-# sysctl net.bridge.bridge-nf-call-iptables=1
-# sysctl net.bridge.bridge-nf-call-ip6tables=1
+sysctl net.bridge.bridge-nf-call-iptables=1
+sysctl net.bridge.bridge-nf-call-ip6tables=1
 
 exit 0

--- a/tests/bootstrap-vagrant.sh
+++ b/tests/bootstrap-vagrant.sh
@@ -7,6 +7,8 @@ sed -i 's/SELINUX=\(disabled\|enforcing\)/SELINUX=permissive/g' /etc/selinux/con
 sestatus
 
 # workaround for 'bridge-nf-call-ip6tables is disabled' public_agent warning
+modprobe br_netfilter
+
 sysctl net.bridge.bridge-nf-call-iptables=1
 sysctl net.bridge.bridge-nf-call-ip6tables=1
 

--- a/tests/bootstrap-vagrant.sh
+++ b/tests/bootstrap-vagrant.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -x -o errexit
+
+# set selinux to permissive
+sed -i 's/SELINUX=\(disabled\|enforcing\)/SELINUX=permissive/g' /etc/selinux/config
+sestatus
+
+# workaround for 'bridge-nf-call-ip6tables is disabled' public_agent warning
+# sysctl net.bridge.bridge-nf-call-iptables=1
+# sysctl net.bridge.bridge-nf-call-ip6tables=1
+
+exit 0

--- a/tests/vagrant-hosts.yml
+++ b/tests/vagrant-hosts.yml
@@ -2,9 +2,13 @@
 ---
 - name: bootstrap
   memory: 512
+  ip: 192.168.0.10
 - name: master
   memory: 512
+  ip: 192.168.0.20
 - name: public_agent
   memory: 512
+  ip: 192.168.0.30
 - name: private_agent
   memory: 512
+  ip: 192.168.0.40

--- a/tests/vagrant-hosts.yml
+++ b/tests/vagrant-hosts.yml
@@ -1,14 +1,14 @@
 # Vagrant test nodes configuration
 ---
 - name: bootstrap
-  memory: 512
+  memory: 1024
   ip: 192.168.0.10
 - name: master
-  memory: 512
+  memory: 1024
   ip: 192.168.0.20
 - name: public_agent
-  memory: 512
+  memory: 1024
   ip: 192.168.0.30
 - name: private_agent
-  memory: 512
+  memory: 1024
   ip: 192.168.0.40

--- a/tests/vars.yaml.sample
+++ b/tests/vars.yaml.sample
@@ -1,0 +1,24 @@
+# Sample Ansible vars file for testing playbooks with Vagrant
+---
+cluster_name: my-cluster
+dcos_download_url: https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh?_ga=2.177384293.1745923283.1502273950-1637564556.1479832876
+epel_repo_url: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
+bootstrap_server_port: 5000
+loopback_ip: 127.0.0.1
+cloud: vagrant
+local_ips:
+  - 85.191.81.60
+  - 83.85.190.253
+  - 92.111.228.8
+dns_servers:
+  - 8.8.4.4
+  - 8.8.8.8
+spartan_ips:
+  - 198.51.100.1
+  - 198.51.100.2
+  - 198.51.100.3
+packet_auth_token: foo
+packet_region: ams1
+dcos_download_path: /opt/dcos
+net_interface: eth1
+net_interface_label: eth1

--- a/vagrant-hosts.yml
+++ b/vagrant-hosts.yml
@@ -1,0 +1,10 @@
+# Vagrant test nodes configuration
+---
+- name: bootstrap
+  memory: 512
+- name: master
+  memory: 512
+- name: public_agent
+  memory: 512
+- name: private_agent
+  memory: 512

--- a/vars.yaml.example
+++ b/vars.yaml.example
@@ -19,3 +19,5 @@ spartan_ips:
 packet_auth_token: foo
 packet_region: ams1
 dcos_download_path: /opt/dcos
+net_interface: bond0
+net_interface_label: bond0_0

--- a/vars.yaml.example
+++ b/vars.yaml.example
@@ -18,3 +18,4 @@ spartan_ips:
   - 198.51.100.3
 packet_auth_token: foo
 packet_region: ams1
+dcos_download_path: /opt/dcos


### PR DESCRIPTION
- added a multi-node vagrant environment with a bootstrap step to set selinux to permissive on the official Centos7 box (theres a reboot before Ansible provisioning through the `vagrant-reload` plugin)
- added `dcos_download_path` Ansible var for allowing install dirs other than `/root`
- added `net_interface`\`net_interface_label` (could use better naming here) for the network interfaces of the nodes (i have eth1 on vagrant)
- added testing info to readme
